### PR TITLE
修复不能修改仓库名部署的Bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Install and Build 🔧 
         env:
           CF_DOMAIN: ${{ secrets.CF_DOMAIN }} # CF-Workers域名
+          REPO_NAME: ${{ github.event.repository.name }}
+          BASE_PATH: ${{ secrets.BASE_PATH }} # 页面Base-path，默认"/{repo_name}"如"/pikpak"
         run: |
           [ $CF_DOMAIN ] && sed -i "s/cors.z7.workers.dev/$CF_DOMAIN/g" src/utils/axios.ts
+          [ $BASE_PATH ] || BASE_PATH="/${REPO_NAME}"
+          [ "$BASE_PATH" != "/pikpak" ] && sed -i "s|/pikpak|$BASE_PATH|g" vite.config.ts
           npm install
           npm run build
           


### PR DESCRIPTION
1. 自适应仓库名部署。
2. 可选手动配置`BASE_PATH`，部署到根目录配置`/`即可。